### PR TITLE
Vx.0.0.14 - Move off of depreciated momentJS

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@create-electron-foundation/cli",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/cli/template/base/electron/main/logger/index.ts
+++ b/cli/template/base/electron/main/logger/index.ts
@@ -2,7 +2,10 @@ import { app } from 'electron'
 import log from 'electron-log/main'
 import path from 'path'
 import { SESSION_ID, electronLogMessageFormat } from '../utils/consts'
-import moment from 'moment'
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+
+dayjs.extend(utc)
 
 // Initialize electron-log. This is optional but recommended if you also log from renderer processes.
 // It allows renderers to use `import log from 'electron-log/renderer'`
@@ -22,7 +25,7 @@ try {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     log.transports.file.resolvePathFn = (variables: any, message: any) => {
-      const now = moment().utc()
+      const now = dayjs().utc()
       const year = now.year().toString()
       const month = (now.month() + 1).toString().padStart(2, '0')
       const day = now.date().toString().padStart(2, '0')

--- a/cli/template/base/package.json
+++ b/cli/template/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-electron-foundation",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "main": "./dist-electron/main/index.js",
   "type": "commonjs",
   "engines": {
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "~5.80.7",
-    "moment": "~2.30.1",
+    "dayjs": "~1.11.13",
     "react": "~19.1.0",
     "react-dom": "~19.1.0",
     "dotenv": "~16.5.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-electron-foundation",
   "type": "module",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "An interactive CLI to bootstrap a modern, type-safe, and scalable Electron application.",
   "author": "Reed Turgeon <turgeon.devd@gmail.com>",
   "repository": {


### PR DESCRIPTION
## 🚀 Description

Removed the single usage of moment to get a utc timestamp to use DayJS instead.

This was used in the electron logging so all configurations are effected.

Fixes # (issue)

## ✅ Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update

## ⚙️ Affected Configurations

- [x] Tanstack Router : Tailwind
- [x] Tanstack Router : Tailwind : SQLite & Drizzle
- [x] Tanstack Router : CSS
- [x] Tanstack Router : CSS : SQLite & Drizzle
- [x] React Router : Tailwind
- [x] React Router : Tailwind : SQLite & Drizzle
- [x] React Router : CSS
- [x] React Router : CSS : SQLite & Drizzle

## 🧪 How Has This Been Tested?

it hasnt

### Local

- [x] MacOS
- [ ] Windows
- [ ] Linux

### Github Workflows

✅

## 📸 Screenshots

n.a.

## 📜 Checklist:

- [x] I have read the [**Contributing Guide**](../CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have run `make laf` to lint and format my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run `make batch-test` to ensure all existing and new tests pass
- [x] Any dependent changes have been merged and published in downstream modules
