### PR TITLE
Project Name Conflicts W/local directory (#56)

### DIFF
--- a/cli/src/helpers/scaffoldProject.ts
+++ b/cli/src/helpers/scaffoldProject.ts
@@ -28,7 +28,7 @@ export const scaffoldProject = async (config: CLIResults): Promise<void> => {
   // CHECK: if the project directory already exists
   if (fs.existsSync(config.project_dir)) {
     const shouldOverwrite = await p.confirm({
-      message: `Directory ${config.project_dir} already exists. Overwrite?`,
+      message: `${chalk.bold.red('Directory already exists: ')}${chalk.red('Backup this directory and continue? > ')}${chalk.red(config.project_dir)}`,
       initialValue: false,
     })
 

--- a/cli/src/helpers/selectBoilerplate.ts
+++ b/cli/src/helpers/selectBoilerplate.ts
@@ -25,7 +25,6 @@ const handleRouter = (config: Readonly<CLIResults>) => {
     const reactRouterSrc = isTailwind
       ? path.join(routerSrc, 'reactRouter', 'with-tailwind')
       : path.join(routerSrc, 'reactRouter', 'base')
-    logger.info(`reactRouterSrc PATH: ${reactRouterSrc}`)
 
     safeCopy(
       path.join(reactRouterSrc, 'routes'),
@@ -43,7 +42,6 @@ const handleRouter = (config: Readonly<CLIResults>) => {
     const tanstackSrc = isTailwind
       ? path.join(routerSrc, 'tanstackRouter', 'with-tailwind')
       : path.join(routerSrc, 'tanstackRouter', 'base')
-    logger.info(`tanstackSrc PATH: ${tanstackSrc}`)
 
     safeCopy(path.join(tanstackSrc, 'routes'), path.join(routerDest, 'routes'))
   }


### PR DESCRIPTION
## 🚀 Description

When there is a conflicting directory name then the user is prompted to backup this existing directory (<name>.backup.timestamp) and continue

Fixes # (issue)

## ✅ Type of change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 This change requires a documentation update

## ⚙️ Affected Configurations

- [x] Tanstack Router : Tailwind
- [x] Tanstack Router : Tailwind : SQLite & Drizzle
- [x] Tanstack Router : Vanilla CSS
- [x] Tanstack Router : Vanilla CSS : SQLite & Drizzle
- [x] React Router : Tailwind
- [x] React Router : Tailwind : SQLite & Drizzle
- [x] React Router : Vanilla CSS
- [x] React Router : Vanilla CSS : SQLite & Drizzle

## 🧪 How Has This Been Tested?

This is a tiny change after extensive recent release testing for @latest === V1.1.0

### Local

- [x] MacOS
- [ ] Windows
- [ ] Linux

### Github Workflows

✅
